### PR TITLE
fix: feat item order

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Tech used:
 
 ## Deployment
 
-Will deploy to vercel when all the code is updated for Next.js
+Deployed on vercel: https://internet-provider-ui-nextjs.vercel.app/
 
 
 ## Payment testing

--- a/src/components/pages/Home/FeaturesItem.tsx
+++ b/src/components/pages/Home/FeaturesItem.tsx
@@ -18,7 +18,7 @@ export default function FeaturesItem(props: FeaturesItemProps) {
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-2 items-center md:gap-4">
-      <div className={`sm:w-[32rem] lg:order-${imageOrder}`}>
+      <div className={`sm:w-[32rem] md:order-${imageOrder}`}>
         <Image
           loading="lazy"
           src={imgSrc}
@@ -26,7 +26,7 @@ export default function FeaturesItem(props: FeaturesItemProps) {
           alt="Feature image"
         />
       </div>
-      <div className={`sm:w-[32rem] text-start p-3 lg:p-5 lg:order-${textOrder}`}>
+      <div className={`sm:w-[32rem] text-start p-3 lg:p-5 md:order-${textOrder}`}>
         <h2>{heading}</h2>
         <p>{subHeading}</p>
         <button


### PR DESCRIPTION
Tailwindd's `'lg:order-#` class doesn't work in my app for some reason. The positions are all ordered to the left rather than alternating. I opted for `md` which does work, though that produces alternating instead of constant alignments when shrinking the screen size. But I'll take mobile and desktop views working correctly, and the tablet one will have that bug...