### PR TITLE
fix: overflow no scrollbar for feature images

### DIFF
--- a/src/app/globals.scss
+++ b/src/app/globals.scss
@@ -52,12 +52,6 @@ a, .btn-link {
 
 body {
   color: rgb(var(--foreground-rgb));
-  // background: linear-gradient(
-  //     to bottom,
-  //     transparent,
-  //     rgb(var(--background-end-rgb))
-  //   )
-  //   rgb(var(--background-start-rgb));
 }
 
 @layer utilities {

--- a/src/components/atoms/AnimateIn/AnimateIn.css
+++ b/src/components/atoms/AnimateIn/AnimateIn.css
@@ -1,22 +1,27 @@
 .transition-box{
     transition: transform 0.5s, opacity 0.5s;
 }
+
 .transition-box.left{
     transform: translateX(-200px);
     opacity: 0;
 }
+
 .transition-box.right{
     transform: translateX(200px);
     opacity: 0;
 }
+
 .transition-box.top{
     transform: translateY(-200px) rotate(360deg);
     opacity: 0;
 }
+
 .transition-box.bottom{
     transform: translateY(200px) scaleX(3) scaleY(3);
     opacity: 0;
 }
+
 .transition-box.active{
     transform: translateX(0);
     opacity: 1;

--- a/src/components/pages/Home/FeatureSummaryItem.tsx
+++ b/src/components/pages/Home/FeatureSummaryItem.tsx
@@ -12,15 +12,12 @@ export default function FeaturesSummaryItem(props: FeaturesSummaryItemProps) {
   return (
     <div className="">
       <div className="grid grid-cols-12">
-
         <Image src={imgSrc} loading="lazy" alt="Feature image" className="col-span-3 text-end mt-2 justify-self-end me-4" />
-
         <div className="col-span-9 text-start">
           <AnimateIn>
             <h4>{heading}</h4>
             <p>{subHeading}</p>
           </AnimateIn>
-
         </div>
       </div>
     </div>

--- a/src/components/pages/Home/Home.tsx
+++ b/src/components/pages/Home/Home.tsx
@@ -9,7 +9,7 @@ import GetConnected from './GetConnected'
 
 export default function Home() {
   return (
-    <>
+    <div style={{ overflow: 'hidden', width: '100%' }}>
       <HeroSection />
       <WhyChooseUs />
       <FeaturesSummaryUnleash />
@@ -18,6 +18,6 @@ export default function Home() {
       <FeaturesSpeed dark={true} />
       <Testimonials />
       <GetConnected />
-    </>
+    </div>
   )
 }


### PR DESCRIPTION
The ImageTransition that pushed images to the side until transitioning them to the part of the page desired, created a scrollbar which is now hidden